### PR TITLE
remove spurious peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,10 +102,6 @@
   "dependencies": {
     "tslib": "^1.9.2"
   },
-  "peerDependencies": {
-    "@angular/common": ">= 5.0.0",
-    "@angular/core": ">= 5.0.0"
-  },
   "devDependencies": {
     "@angular/animations": "6.0.4",
     "@angular/common": "6.0.4",


### PR DESCRIPTION
angular core and angular common are dev deps, not peer deps.  this causes absence of angular warnings in non-angular users